### PR TITLE
Rename Swedish locale from se to sv

### DIFF
--- a/app/locales/sv.json
+++ b/app/locales/sv.json
@@ -1,6 +1,6 @@
 {
   "isRtl": false,
-  "lang": "se",
+  "lang": "sv",
   "title": "Cassandra - GLAM-statistik",
   "index": {
     "title": "Ett statistik- och analysverktyg för kulturarvsorganisationer som samarbetar med Wikimediarörelsen."

--- a/app/pages/views/templates/sidebar.hbs
+++ b/app/pages/views/templates/sidebar.hbs
@@ -1,7 +1,7 @@
 <select name="lang" id="langSelect" style="visibility: hidden;">
   <option value="en">English</option>
   <option value="he">עברית</option>
-  <option value="se">Swedish</option>
+  <option value="sv">Swedish</option>
 </select>
 <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
 <script defer>

--- a/app/server.js
+++ b/app/server.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const cookieParser = require('cookie-parser');
 var config = require('./config/config');
 
-const locales = ['en', 'he', 'se']
+const locales = ['en', 'he', 'sv']
 const localesDir = __dirname + '/locales';
 const localesDicts = locales.reduce((map, locale) => {
     const localJson = JSON.parse(fs.readFileSync(`${localesDir}/${locale}.json`).toString());


### PR DESCRIPTION
If based on language code (rather than country) then Swedish is either
'sv' or 'sv-se'.